### PR TITLE
Pre-processing team name and topic_id in order to avoid RocketChat fails

### DIFF
--- a/rocketc/rocketc.py
+++ b/rocketc/rocketc.py
@@ -297,8 +297,9 @@ class RocketChatXBlock(XBlock, XBlockWithSettingsMixin, StudioEditableXBlockMixi
 
         if team is None:
             return False
-
-        group_name = "-".join(["Team", team["topic_id"], team["name"]])
+        topic_id = re.sub(r'\W+', '', team["topic_id"])
+        team_name = re.sub(r'\W+', '', team["name"])
+        group_name = "-".join(["Team", topic_id, team_name])
         group_info = api.search_rocket_chat_group(group_name)
         self.team_channel = group_name
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.6
+current_version = 0.2.7
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import setup
 
-__version__ = '0.2.6'
+__version__ = '0.2.7'
 
 
 def package_data(pkg, roots):


### PR DESCRIPTION
## Description 
Rocketchat doesn't allow special character, so theses changes pre processing the  team name and topic_id to avoid errors in group's creation.

## Reviewers 
- [x] @jfavellar90 
- [ ] @diegomillan  
